### PR TITLE
🐛 fix: add missing 'part' html attribute on several components

### DIFF
--- a/src/components/Divider/Divider.ts
+++ b/src/components/Divider/Divider.ts
@@ -7,7 +7,7 @@ export class CandyDivider extends LitElement {
   static styles = DividerStyle;
 
   render() {
-    return html` <div class="divider-container"><div></div></div> `;
+    return html`<div part="divider" class="divider-container"><div></div></div> `;
   }
 }
 

--- a/src/components/Icon/Icon.ts
+++ b/src/components/Icon/Icon.ts
@@ -17,7 +17,7 @@ export class CandyBadge extends LitElement {
   render() {
     const iconClasses = iconSize[this.size];
     return html`
-      <div class=${iconClasses}>
+      <div class=${iconClasses} part="icon">
         <slot name="icon"></slot>
       </div>
     `;

--- a/src/components/Input/Input.ts
+++ b/src/components/Input/Input.ts
@@ -22,7 +22,7 @@ export class CandyInput extends LitElement {
   shortCut = "⌘K";
 
   render() {
-    return html`<div class="input-container">
+    return html`<div class="input-container" part="input">
       <label for="search">${this.label}</label>
       <div class="input-box">
         <input

--- a/src/components/Link/Link.ts
+++ b/src/components/Link/Link.ts
@@ -21,7 +21,7 @@ export class CandyLink extends LitElement {
   target = "_blank";
 
   render() {
-    return html`<a class="link-container" href=${this.url} target=${this.target}
+    return html`<a class="link-container" href=${this.url} target=${this.target} part="link"
       >${this.label}</a
     > `;
   }

--- a/src/components/Sidebar/Element/Element.ts
+++ b/src/components/Sidebar/Element/Element.ts
@@ -31,6 +31,7 @@ export class CandySidebarElement extends LitElement {
 
     return html`
       <button
+        part="sidebar-element"
         href="#"
         class="${"element-container " + styleClass} ${!this.collapsed ? "element-container-extended" : null}"
         ?disabled="${this.disabled}"

--- a/src/components/Spinner/Spinner.ts
+++ b/src/components/Spinner/Spinner.ts
@@ -17,7 +17,7 @@ export class CandySpinner extends LitElement {
   render() {
     const spinnerClass = spinnerSize[this.size];
     return html`
-      <div class="spinner-container">
+      <div class="spinner-container" part="spinner">
         <svg
           role="status"
           class=${spinnerClass}

--- a/src/components/Switch/Switch.ts
+++ b/src/components/Switch/Switch.ts
@@ -17,6 +17,7 @@ export class CandySwitch extends LitElement {
     const bgColor = this.activated ? "blue" : "gray";
     const switchPosition = this.activated ? "translate-x-5" : "translate-x-0";
     return html`<button
+      part="switch"
       type="button"
       class=${"switch " + bgColor}
       role="switch"

--- a/src/components/Text/Text.ts
+++ b/src/components/Text/Text.ts
@@ -16,7 +16,7 @@ export class CandyText extends LitElement {
   }
 
   render() {
-    return html` <div class="prose">${this.returnString()}</div> `;
+    return html`<div part="prose" class="prose">${this.returnString()}</div> `;
   }
 }
 

--- a/src/components/Topbar/Element/TopbarElement.ts
+++ b/src/components/Topbar/Element/TopbarElement.ts
@@ -15,7 +15,7 @@ export class CandyTopbarElement extends LitElement {
 
   render() {
     return html`
-      <li>
+      <li part="topbar-element">
         <div class="title">
           ${this.label}
         </div>

--- a/src/components/Topbar/Topbar.ts
+++ b/src/components/Topbar/Topbar.ts
@@ -35,7 +35,7 @@ export class CandyTopbar extends LitElement {
 
   render() {
     return html`
-      <header class="topbar-container">
+      <header class="topbar-container" part="topbar">
         <div class="${this.mobile ? "logo-reduced" : "logo"}">
           <a href="/">
             ${this.mobile ?

--- a/src/components/Topbar/TopbarStyle.ts
+++ b/src/components/Topbar/TopbarStyle.ts
@@ -2,7 +2,7 @@ import { css } from "lit";
 
 export default css`
   .topbar-container {
-    background-color: #fff;
+    background-color: transparent;
     flex: 1 1 0%;
     padding: 0.5rem;
     margin-left: auto;


### PR DESCRIPTION
# Pull request for Candy-doc components library

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../../CONTRIBUTING.md) to
this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right
  side). Don't request your master!
- [X] Make sure you are making a pull request against the **main branch** (left
  side).
- [X] Check the commit's or even all commits' message styles matches our
  requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit
  test.

## Description

During the storybook and project update (#43), some components have been updated with the addition of a part html attribute. However it has not been applied to all.

Thus, it has been corrected here.

The 'part' html attribute is used as a css selector for shadow-dom elements so external css files can update its style

❤️ Thank you!
