### PR TITLE
✨ feat: add sidebar element's options icons

### DIFF
--- a/src/components/Sidebar/Element/Element.ts
+++ b/src/components/Sidebar/Element/Element.ts
@@ -39,6 +39,11 @@ export class CandySidebarElement extends LitElement {
       >
         <slot name="icon"></slot>
         <p>${!this.collapsed ? this.label : null}</p>
+        <div class="end-icons">
+          <div class="options-container">
+            <slot name="options"></slot>
+          </div>
+        </div>
       </button>
     `;
   }

--- a/src/components/Sidebar/Element/ElementStyle.ts
+++ b/src/components/Sidebar/Element/ElementStyle.ts
@@ -48,4 +48,25 @@ export default css`
     all: unset;
     margin-left: 0.5rem;
   }
+
+  .end-icons {
+    display: flex;
+    justify-content: end;
+    flex-grow: 1;
+  }
+
+  .options-container {
+    display: flex;
+    gap: 1rem;
+    padding: 0 1rem;
+  }
+
+  .options-container > ::slotted(*) {
+    transition: 0.1s ease-in-out;
+  }
+
+  .options-container > ::slotted(*:hover) {
+    transform: scale(1.1);
+    transition: 0.2s ease-in-out;
+  }
 `;

--- a/src/stories/Accordion/AccordionMeta.ts
+++ b/src/stories/Accordion/AccordionMeta.ts
@@ -103,5 +103,10 @@ export const meta = {
         disable: true,
       },
     },
+    hasOptions: {
+      table: {
+        disable: true,
+      },
+    },
   },
 };

--- a/src/stories/Sidebar/Element/Element.stories.ts
+++ b/src/stories/Sidebar/Element/Element.stories.ts
@@ -18,6 +18,10 @@ const renderElement = (
   ?collapsed=${args.collapsed}
 >
   ${args.hasIcon ? html`<fa-icon slot="icon" class=${icon} size="2em"></fa-icon>` : null}
+  ${args.hasOptions
+    ? html`<fa-icon slot="options" class="fa-solid fa-location-crosshairs"></fa-icon
+      ><fa-icon slot="options" class="fa-regular fa-eye"></fa-icon>`
+    : null}
 </candy-sidebar-element>`;
 
 export default {
@@ -43,5 +47,17 @@ export const ElementWithIcon: Story = {
     disabled: false,
     collapsed: false,
     hasIcon: true,
+    hasOptions: false,
+  },
+};
+
+export const ElementWithOptions: Story = {
+  args: {
+    label: "Candy-Doc",
+    active: false,
+    disabled: false,
+    collapsed: false,
+    hasIcon: true,
+    hasOptions: true,
   },
 };

--- a/src/stories/Sidebar/Element/ElementMeta.ts
+++ b/src/stories/Sidebar/Element/ElementMeta.ts
@@ -1,5 +1,6 @@
 export type CandyElementControl = {
   hasIcon: boolean;
+  hasOptions: boolean;
 };
 
 export const meta = {
@@ -75,7 +76,25 @@ export const meta = {
         },
       },
     },
+    optionsSlot: {
+      name: "options",
+      description: "Slot for the element's options icon",
+      table: {
+        category: "slots",
+        type: {
+          summary: "HTMLElement",
+        },
+        defaultValue: {
+          summary: "options",
+        },
+      },
+    },
     hasIcon: {
+      table: {
+        disable: true,
+      },
+    },
+    hasOptions: {
       table: {
         disable: true,
       },


### PR DESCRIPTION
# Pull request for Candy-doc components library

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../../CONTRIBUTING.md) to
this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right
  side). Don't request your master!
- [X] Make sure you are making a pull request against the **main branch** (left
  side).
- [X] Check the commit's or even all commits' message styles matches our
  requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit
  test.

## Description

Same as accordion, options icons slot has been added to the component to use with sidebar 

❤️ Thank you!
