### PR TITLE
✨ refactor: topbar and sidebar responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A Lit-Element library made to generate Candy-Doc dashboard
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 ## Table of Contents
 
 - [Installation 🚀](#installation-)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A Lit-Element library made to generate Candy-Doc dashboard
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 ## Table of Contents
 
 - [Installation 🚀](#installation-)

--- a/src/components/Accordion/Accordion.ts
+++ b/src/components/Accordion/Accordion.ts
@@ -71,7 +71,9 @@ export class CandyAccordion extends PopoverInComponentHandler {
       this.minimizeOptions && this.countOptionsSlotAmount() >= 2
         ? html` <div class="end-icons">
             <candy-popover class="options-container" side=${this.position}>
-              <div class="vertical-menu-icon" data-testid="accordion-options-icon">${verticalMenuIcon}</div>
+              <div class="vertical-menu-icon" data-testid="accordion-options-icon">
+                ${verticalMenuIcon}
+              </div>
               <div slot="content" class="options-container">
                 <slot name="options"></slot>
               </div>

--- a/src/components/FloatingButton/FloatingButtonStyle.ts
+++ b/src/components/FloatingButton/FloatingButtonStyle.ts
@@ -10,7 +10,7 @@ export default css`
     align-items: center;
     justify-content: center;
     min-height: 2.5rem;
-    z-index: 999;
+    z-index: 100;
   }
 
   .button:hover {

--- a/src/components/SidebarDoc/DocElement/DocElementStyle.ts
+++ b/src/components/SidebarDoc/DocElement/DocElementStyle.ts
@@ -5,7 +5,7 @@ export default css`
     width: 100%;
     margin-bottom: 0.25rem;
     border-radius: 0.375rem;
-    padding: 0.5rem;
+    padding: 0.2rem 0;
     display: flex;
     align-items: center;
     font-size: 1rem;
@@ -44,6 +44,7 @@ export default css`
     all: unset;
     width: 100%;
     text-align: left;
+    margin-left: 0.5rem;
     transition: 0.1s ease-in-out;
   }
 

--- a/src/components/SidebarDoc/DocTitle/DocTitleStyle.ts
+++ b/src/components/SidebarDoc/DocTitle/DocTitleStyle.ts
@@ -3,11 +3,11 @@ import { css } from "lit";
 export default css`
   .element-container {
     width: 100%;
-    margin-bottom: 0.25rem;
     border-radius: 0.375rem;
-    padding: 0.5rem;
+    padding: 0.25rem;
     display: flex;
     align-items: center;
+    justify-content: flex-start;
     font-size: 1rem;
     line-height: 1.5rem;
     font-weight: 500;
@@ -20,7 +20,7 @@ export default css`
   }
 
   .title-container {
-    padding-bottom: 1rem;
+    padding-bottom: 0.75rem;
   }
 
   p {

--- a/src/components/SidebarDoc/SidebarDocStyle.ts
+++ b/src/components/SidebarDoc/SidebarDocStyle.ts
@@ -3,12 +3,9 @@ import { css } from "lit";
 export default css`
   .sidebar-doc-container {
     display: flex;
-    height: 100%;
     border-right: 1px rgb(229 231 235);
-    padding-top: 1rem;
     background-color: transparent;
     border-radius: 10px;
-    overflow-y: auto;
   }
 
   section {

--- a/src/components/Topbar/Element/TopbarElementStyle.ts
+++ b/src/components/Topbar/Element/TopbarElementStyle.ts
@@ -5,7 +5,7 @@ export default css`
     display: flex;
     justify-content: center;
     align-items: center;
-    color: black;
+    color: inherit;
   }
 
   .title {

--- a/src/components/Topbar/Topbar.ts
+++ b/src/components/Topbar/Topbar.ts
@@ -28,33 +28,29 @@ export class CandyTopbar extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.resize();
-    window.addEventListener("resize", this.resize);
+    this.defineIfDeviceIsMobile();
+    window.addEventListener("resize", this.defineIfDeviceIsMobile);
   }
 
   disconnectedCallback() {
-    window.removeEventListener("resize", this.resize);
+    window.removeEventListener("resize", this.defineIfDeviceIsMobile);
     super.disconnectedCallback();
   }
 
   updated(changedProperties: PropertyValues<this>) {
     if (this.mobile && changedProperties.has("isopen")) {
-      this.handleBurgerClick(this.isopen);
+      this.handleMenuState();
     }
   }
 
   protected firstUpdated(): void {
     if (this.mobile) {
-      this.handleBurgerClick(this.isopen);
+      this.handleMenuState();
     }
   }
 
-  resize = () => {
-    if (window.innerWidth < 768) {
-      this.mobile = true;
-    } else {
-      this.mobile = false;
-    }
+  defineIfDeviceIsMobile = () => {
+    this.mobile = window.innerWidth < 768;
   };
 
   openDrawer() {
@@ -82,15 +78,18 @@ export class CandyTopbar extends LitElement {
     this.dispatchEvent(eventOnChange);
   };
 
-  handleBurgerClick = (openValue: boolean) => {
-    this.isopen = openValue;
-    this.emitValueChangeEvent(openValue);
-    if (openValue) {
+  handleMenuState = () => {
+    if (this.isopen) {
       this.openDrawer();
     } else {
       this.closeDrawer();
     }
+    this.emitValueChangeEvent(this.isopen);
   };
+
+  updateIsOpenValue = (newValue: boolean) => {
+    this.isopen = newValue;
+  }
 
   render() {
     const displaySlot = html`<slot></slot>`;
@@ -98,7 +97,7 @@ export class CandyTopbar extends LitElement {
     const displayBurger = html` <button
       part="tobpar-burger"
       id="topbar-burger"
-      @click=${() => this.handleBurgerClick(!this.isopen)}
+      @click=${() => this.updateIsOpenValue(!this.isopen)}
     >
       <span></span>
       <span></span>
@@ -111,7 +110,7 @@ export class CandyTopbar extends LitElement {
       class="topbar-drawer display-none"
     >
       <div
-        @click=${() => this.handleBurgerClick(!this.isopen)}
+        @click=${() => this.updateIsOpenValue(!this.isopen)}
         class="topbar-drawer-backdrop"
       ></div>
       <aside part="tobpar-drawer-content" class="topbar-drawer-content">
@@ -132,8 +131,8 @@ export class CandyTopbar extends LitElement {
       <div class="${this.mobile ? "logo-reduced" : "logo"}">
         <a href="/">
           ${this.mobile
-            ? html`<candy-logo-mark></candy-logo-mark>`
-            : html`<candy-logo-horizontal></candy-logo-horizontal>`}
+        ? html`<candy-logo-mark></candy-logo-mark>`
+        : html`<candy-logo-horizontal></candy-logo-horizontal>`}
         </a>
       </div>
       <nav class="navbar">

--- a/src/components/Topbar/Topbar.ts
+++ b/src/components/Topbar/Topbar.ts
@@ -6,6 +6,10 @@ import "../Logos/LogoMark";
 import "../Logos/LogoHorizontal";
 import "../Divider";
 
+export type CandyTopbarProps = {
+  isopen: boolean;
+};
+
 @customElement("candy-topbar")
 export class CandyTopbar extends LitElement {
   static styles = TopbarStyle;

--- a/src/components/Topbar/Topbar.ts
+++ b/src/components/Topbar/Topbar.ts
@@ -1,17 +1,26 @@
-import { LitElement, html } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { LitElement, PropertyValues, html } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
 
 import TopbarStyle from "./TopbarStyle";
 import "../Logos/LogoMark";
 import "../Logos/LogoHorizontal";
-import "../Input/Input";
+import "../Divider";
 
 @customElement("candy-topbar")
 export class CandyTopbar extends LitElement {
   static styles = TopbarStyle;
 
+  @query("#topbar-burger")
+  burgerButton!: HTMLElement;
+
+  @query("#drawer")
+  drawer!: HTMLElement;
+
   @state()
   mobile = false;
+
+  @property({ type: Boolean })
+  isopen = false;
 
   connectedCallback() {
     super.connectedCallback();
@@ -24,6 +33,18 @@ export class CandyTopbar extends LitElement {
     super.disconnectedCallback();
   }
 
+  updated(changedProperties: PropertyValues<this>) {
+    if (this.mobile && changedProperties.has("isopen")) {
+      this.handleBurgerClick(this.isopen);
+    }
+  }
+
+  protected firstUpdated(): void {
+    if (this.mobile) {
+      this.handleBurgerClick(this.isopen);
+    }
+  }
+
   resize = () => {
     if (window.innerWidth < 768) {
       this.mobile = true;
@@ -32,23 +53,92 @@ export class CandyTopbar extends LitElement {
     }
   };
 
+  openDrawer() {
+    this.burgerButton.classList.add("active");
+    this.drawer.classList.remove("display-none");
+    this.drawer.classList.remove("topbar-drawer-close");
+    this.drawer.classList.add("topbar-drawer-active");
+  }
+
+  closeDrawer() {
+    this.burgerButton.classList.remove("active");
+    this.drawer.classList.remove("topbar-drawer-active");
+    this.drawer.classList.add("topbar-drawer-close");
+    setTimeout(() => {
+      this.drawer.classList.add("display-none");
+    }, 150);
+  }
+
+  emitValueChangeEvent = (openValue: boolean) => {
+    const eventOnChange = new CustomEvent("onchange", {
+      bubbles: false,
+      composed: true,
+      detail: { value: openValue },
+    });
+    this.dispatchEvent(eventOnChange);
+  };
+
+  handleBurgerClick = (openValue: boolean) => {
+    this.isopen = openValue;
+    this.emitValueChangeEvent(openValue);
+    if (openValue) {
+      this.openDrawer();
+    } else {
+      this.closeDrawer();
+    }
+  };
+
   render() {
-    return html`
-      <header class="topbar-container" part="topbar">
-        <div class="${this.mobile ? "logo-reduced" : "logo"}">
-          <a href="/">
-            ${this.mobile
-              ? html`<candy-logo-mark></candy-logo-mark>`
-              : html`<candy-logo-horizontal></candy-logo-horizontal>`}
-          </a>
+    const displaySlot = html`<slot></slot>`;
+
+    const displayBurger = html` <button
+      part="tobpar-burger"
+      id="topbar-burger"
+      @click=${() => this.handleBurgerClick(!this.isopen)}
+    >
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>`;
+
+    const displayDrawer = html` <div
+      id="drawer"
+      part="tobpar-drawer"
+      class="topbar-drawer display-none"
+    >
+      <div
+        @click=${() => this.handleBurgerClick(!this.isopen)}
+        class="topbar-drawer-backdrop"
+      ></div>
+      <aside part="tobpar-drawer-content" class="topbar-drawer-content">
+        <div part="tobpar-drawer-box" class="topbar-drawer-box">
+          <div class="logo-reduced">
+            <a href="/">
+              <candy-logo-mark></candy-logo-mark>
+            </a>
+          </div>
+          ${displaySlot}
         </div>
-        <nav class="navbar">
-          <ul>
-            <slot></slot>
-          </ul>
-        </nav>
-      </header>
-    `;
+        <candy-divider></candy-divider>
+        <slot name="drawer-content"></slot>
+      </aside>
+    </div>`;
+
+    return html` <header class="topbar-container" part="topbar">
+      <div class="${this.mobile ? "logo-reduced" : "logo"}">
+        <a href="/">
+          ${this.mobile
+            ? html`<candy-logo-mark></candy-logo-mark>`
+            : html`<candy-logo-horizontal></candy-logo-horizontal>`}
+        </a>
+      </div>
+      <nav class="navbar">
+        <ul>
+          ${this.mobile ? displayBurger : displaySlot}
+        </ul>
+      </nav>
+      ${this.mobile ? displayDrawer : null}
+    </header>`;
   }
 }
 

--- a/src/components/Topbar/Topbar.ts
+++ b/src/components/Topbar/Topbar.ts
@@ -43,12 +43,6 @@ export class CandyTopbar extends LitElement {
     }
   }
 
-  protected firstUpdated(): void {
-    if (this.mobile) {
-      this.handleMenuState();
-    }
-  }
-
   defineIfDeviceIsMobile = () => {
     this.mobile = window.innerWidth < 768;
   };
@@ -69,26 +63,20 @@ export class CandyTopbar extends LitElement {
     }, 150);
   }
 
-  emitValueChangeEvent = (openValue: boolean) => {
-    const eventOnChange = new CustomEvent("onchange", {
-      bubbles: false,
-      composed: true,
-      detail: { value: openValue },
-    });
-    this.dispatchEvent(eventOnChange);
-  };
-
   handleMenuState = () => {
     if (this.isopen) {
       this.openDrawer();
     } else {
       this.closeDrawer();
     }
-    this.emitValueChangeEvent(this.isopen);
   };
 
-  updateIsOpenValue = (newValue: boolean) => {
-    this.isopen = newValue;
+  emitBurgerClickEvent = () => {
+    const eventOnChange = new CustomEvent("onchange", {
+      bubbles: false,
+      composed: true,
+    });
+    this.dispatchEvent(eventOnChange);
   }
 
   render() {
@@ -97,7 +85,7 @@ export class CandyTopbar extends LitElement {
     const displayBurger = html` <button
       part="tobpar-burger"
       id="topbar-burger"
-      @click=${() => this.updateIsOpenValue(!this.isopen)}
+      @click=${this.emitBurgerClickEvent}
     >
       <span></span>
       <span></span>
@@ -110,7 +98,7 @@ export class CandyTopbar extends LitElement {
       class="topbar-drawer display-none"
     >
       <div
-        @click=${() => this.updateIsOpenValue(!this.isopen)}
+        @click=${this.emitBurgerClickEvent}
         class="topbar-drawer-backdrop"
       ></div>
       <aside part="tobpar-drawer-content" class="topbar-drawer-content">

--- a/src/components/Topbar/TopbarStyle.ts
+++ b/src/components/Topbar/TopbarStyle.ts
@@ -11,6 +11,7 @@ export default css`
     flex-direction: row;
     align-items: center;
     min-height: 3rem;
+    color: black;
   }
 
   .logo {
@@ -38,15 +39,157 @@ export default css`
     flex-wrap: wrap;
   }
 
-  ::slotted(*) {
-    display: flex;
-    align-content: center;
-    justify-content: center;
+  a:hover {
+    cursor: pointer;
   }
 
   @media (min-width: 768px) {
     ul {
       column-gap: 5rem;
     }
+  }
+
+  #topbar-burger {
+    display: flex;
+    width: 2rem;
+    height: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem;
+    background: transparent;
+    border: 0;
+    position: relative;
+    z-index: 102;
+  }
+
+  #topbar-burger:hover,
+  .topbar-drawer-backdrop {
+    cursor: pointer;
+  }
+
+  #topbar-burger > span {
+    width: 100%;
+    height: 0.15rem;
+    background: black;
+    transform-origin: right center;
+    transition: all 0.15s linear 0s;
+  }
+
+  #topbar-burger.active > span:nth-child(1) {
+    transform: rotate(-45deg);
+  }
+
+  #topbar-burger.active > span:nth-child(2) {
+    opacity: 0;
+  }
+
+  #topbar-burger.active > span:nth-child(3) {
+    transform: rotate(45deg);
+  }
+
+  .topbar-drawer {
+    display: flex;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 15rem;
+    height: 100vh;
+    z-index: 101;
+    background-color: transparent;
+    transition: 0.15s ease-out;
+  }
+
+  .topbar-drawer-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(100, 100, 100, 0.4);
+    z-index: 101;
+  }
+
+  .topbar-drawer-content {
+    background-color: white;
+    position: absolute;
+    top: 0;
+    overflow-y: scroll;
+    left: -15rem;
+    height: 100%;
+    width: 15rem;
+    z-index: 102;
+    transition: 0.15s ease-out;
+    box-shadow: 1px 1px 20px rgba(175, 175, 175, 0.5);
+  }
+
+  .topbar-drawer-box {
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.5rem;
+  }
+
+  .topbar-drawer.topbar-drawer-active > .topbar-drawer-backdrop {
+    animation: fadeIn 0.15s forwards;
+  }
+
+  .topbar-drawer.topbar-drawer-close > .topbar-drawer-backdrop {
+    animation: fadeOut 0.15s forwards;
+  }
+
+  .topbar-drawer.topbar-drawer-active > .topbar-drawer-content {
+    animation: translateIn 0.15s forwards;
+  }
+
+  .topbar-drawer.topbar-drawer-close > .topbar-drawer-content {
+    animation: translateOut 0.15s forwards;
+  }
+
+  @keyframes fadeIn {
+    from {
+      background-color: rgba(100, 100, 100, 0);
+    }
+
+    to {
+      background-color: rgba(100, 100, 100, 0.4);
+      backdrop-filter: blur(4px);
+    }
+  }
+
+  @keyframes fadeOut {
+    from {
+      background-color: rgba(100, 100, 100, 0.4);
+    }
+
+    to {
+      background-color: rgba(100, 100, 100, 0);
+    }
+  }
+
+  @keyframes translateIn {
+    from {
+      transform: translateX(0%);
+    }
+
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  @keyframes translateOut {
+    from {
+      transform: translateX(100%);
+    }
+
+    to {
+      transform: translateX(0%);
+    }
+  }
+
+  .display-none {
+    display: none;
   }
 `;

--- a/src/components/Topbar/index.ts
+++ b/src/components/Topbar/index.ts
@@ -1,1 +1,2 @@
 import "./Topbar";
+export type { CandyTopbarProps } from "./Topbar";

--- a/src/stories/SidebarDoc/DocSidebar.stories.ts
+++ b/src/stories/SidebarDoc/DocSidebar.stories.ts
@@ -26,9 +26,9 @@ const renderSidebarElements = (element: CandySideBarDocElement): TemplateResult 
 };
 
 const renderSideBar = (args: CandySideBarDocControl) => {
-  return html`<candy-sidebar>
+  return html`<candy-sidebar-doc>
     ${args.elements.map((item) => renderSidebarElements(item))}
-  </candy-sidebar>`;
+  </candy-sidebar-doc>`;
 };
 
 export default {

--- a/src/stories/Topbar/Stories/renderTopbar.ts
+++ b/src/stories/Topbar/Stories/renderTopbar.ts
@@ -1,0 +1,12 @@
+import { html } from "lit";
+
+export const renderTobpar = () => html` <candy-topbar>
+  <candy-topbar-element label="Getting Started"></candy-topbar-element>
+  <candy-topbar-element label="Graph"></candy-topbar-element>
+  <candy-topbar-element label="Contact">
+    <fa-icon slot="icon" class="fa-brands fa-github"></fa-icon>
+  </candy-topbar-element>
+  <candy-topbar-element>
+    <a slot="icon" href="https://google.com"> <fa-icon class="fa-brands fa-github"> </fa-icon></a>
+  </candy-topbar-element>
+</candy-topbar>`;

--- a/src/stories/Topbar/Stories/renderTopbar.ts
+++ b/src/stories/Topbar/Stories/renderTopbar.ts
@@ -1,6 +1,11 @@
 import { html } from "lit";
 
-export const renderTobpar = () => html` <candy-topbar>
+import { CandyTopbarProps } from "../../../components/Topbar";
+
+export const renderTobpar = (args: CandyTopbarProps) => html` <candy-topbar
+  ?isopen=${args.isopen}
+  style="position: relative"
+>
   <candy-topbar-element label="Getting Started"></candy-topbar-element>
   <candy-topbar-element label="Graph"></candy-topbar-element>
   <candy-topbar-element label="Contact">

--- a/src/stories/Topbar/Stories/renderTopbarWithAdditionalContent.ts
+++ b/src/stories/Topbar/Stories/renderTopbarWithAdditionalContent.ts
@@ -1,0 +1,39 @@
+import { html } from "lit";
+import "../../../components/SidebarDoc";
+import "../../../components/SidebarDoc/DocTitle";
+import "../../../components/SidebarDoc/DocElement";
+
+export const renderTopbarWithAdditionalContent = () => html`
+  <candy-topbar>
+    <candy-topbar-element label="Getting Started"></candy-topbar-element>
+    <candy-topbar-element label="Graph"></candy-topbar-element>
+    <candy-topbar-element label="Contact">
+      <fa-icon slot="icon" class="fa-brands fa-github"></fa-icon>
+    </candy-topbar-element>
+    <candy-topbar-element>
+      <a slot="icon" href="https://google.com"> <fa-icon class="fa-brands fa-github"> </fa-icon></a>
+    </candy-topbar-element>
+    <candy-sidebar-doc slot="drawer-content">
+      <candy-sidebar-doc-title label="Lorem ipsum">
+        <candy-sidebar-doc-element label="Ut labore et"></candy-sidebar-doc-element>
+        <candy-sidebar-doc-element label="Nisi ut aliquip"></candy-sidebar-doc-element>
+        <candy-sidebar-doc-element label="Qui dolorem ipsum"></candy-sidebar-doc-element>
+      </candy-sidebar-doc-title>
+      <candy-sidebar-doc-title label="Solor sit amet">
+        <candy-sidebar-doc-element label="Nulla pariatur"></candy-sidebar-doc-element>
+      </candy-sidebar-doc-title>
+      <candy-sidebar-doc-title label="Consectetur">
+        <candy-sidebar-doc-element label="Ut enim ad minima"></candy-sidebar-doc-element>
+      </candy-sidebar-doc-title>
+      <candy-sidebar-doc-title label="Adipiscing">
+        <candy-sidebar-doc-element label="Iure reprehenderit"></candy-sidebar-doc-element>
+      </candy-sidebar-doc-title>
+      <candy-sidebar-doc-title label="Elit">
+        <candy-sidebar-doc-element label="Eius modi tempora"></candy-sidebar-doc-element>
+      </candy-sidebar-doc-title>
+      <candy-sidebar-doc-title label="Eiusmod">
+        <candy-sidebar-doc-element label="Dignissimos ducimus"></candy-sidebar-doc-element>
+      </candy-sidebar-doc-title>
+    </candy-sidebar-doc>
+  </candy-topbar>
+`;

--- a/src/stories/Topbar/TopbarMeta.ts
+++ b/src/stories/Topbar/TopbarMeta.ts
@@ -1,18 +1,60 @@
-export const meta = {
+import { Meta } from "@storybook/web-components";
+import { CandyTopbarProps } from "../../components/Topbar";
+
+export type CandyTopbarControl = {
+  onChange: () => void;
+  drawerContentSlot: string;
+  defaultSlot: string;
+};
+
+export const meta: Meta<CandyTopbarProps & CandyTopbarControl> = {
   component: "candy-topbar",
   parameters: {
     docs: {
       description: {
-        component: "CSS part selector: **topbar**",
+        component:
+          "CSS part selector: \n- **topbar** \n- **tobpar-burger** \n- **tobpar-drawer** \n- **tobpar-drawer-content** \n- **tobpar-drawer-box**",
       },
     },
   },
   argTypes: {
+    isopen: {
+      description: "Handle opening of the topbar's drawer when in mobile view.",
+      table: {
+        category: "props",
+        type: {
+          summary: "Boolean",
+        },
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    onChange: {
+      name: "onchange",
+      description: "Custom event triggered on new open value. It returns the new open value",
+      table: {
+        category: "events",
+        type: {
+          summary: "Function",
+        },
+      },
+    },
+    drawerContentSlot: {
+      name: "drawer-content",
+      description: "Slot containing the additional content for mobile view",
+      table: {
+        category: "Slots",
+        type: {
+          summary: "HTMLElement",
+        },
+      },
+    },
     defaultSlot: {
       name: "default",
       description: "Default slot containing children of the component",
       table: {
-        category: "slots",
+        category: "Slots",
         type: {
           summary: "HTMLElement",
         },

--- a/src/stories/Topbar/topbar.stories.ts
+++ b/src/stories/Topbar/topbar.stories.ts
@@ -12,8 +12,15 @@ export default {
   render: renderTobpar,
 };
 
-export const Topbar: StoryObj = {};
+export const Topbar: StoryObj = {
+  args: {
+    isopen: false,
+  },
+};
 
 export const RenderTopbarWithAdditionalContent: StoryObj = {
+  args: {
+    isopen: false,
+  },
   render: renderTopbarWithAdditionalContent,
 };

--- a/src/stories/Topbar/topbar.stories.ts
+++ b/src/stories/Topbar/topbar.stories.ts
@@ -1,25 +1,19 @@
 import { StoryObj } from "@storybook/web-components";
-import { html } from "lit";
 
 import { meta } from "./TopbarMeta";
+import { renderTobpar } from "./Stories/renderTopbar";
+import { renderTopbarWithAdditionalContent } from "./Stories/renderTopbarWithAdditionalContent";
 import "../../components/Topbar/Topbar";
 import "../../components/Topbar/Element";
-
-const renderTopBar = () => html`<candy-topbar>
-  <candy-topbar-element label="Getting Started"></candy-topbar-element>
-  <candy-topbar-element label="Graph"></candy-topbar-element>
-  <candy-topbar-element label="Contact">
-    <fa-icon slot="icon" class="fa-brands fa-github"></fa-icon>
-  </candy-topbar-element>
-  <candy-topbar-element>
-    <a slot="icon" href="https://google.com"> <fa-icon class="fa-brands fa-github"> </fa-icon></a>
-  </candy-topbar-element>
-</candy-topbar>`;
 
 export default {
   ...meta,
   title: "Components/Topbar",
-  render: renderTopBar,
+  render: renderTobpar,
 };
 
 export const Topbar: StoryObj = {};
+
+export const RenderTopbarWithAdditionalContent: StoryObj = {
+  render: renderTopbarWithAdditionalContent,
+};


### PR DESCRIPTION
# Pull request for Candy-doc components library

## Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../../CONTRIBUTING.md) to
this repository.

- [X] Make sure you are requesting to **pull a feature/bugfix branch** (right
  side). Don't request your master!
- [X] Make sure you are making a pull request against the **main branch** (left
  side).
- [X] Check the commit's or even all commits' message styles matches our
  requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit
  test.

## Description

Handle responsiveness of topbar and sidebar on mobile view

Tobpar:
- Add html content inside topbar to display a drawer available if viewport width is < 768px
- Add new property **isopen** to handle opening and closing of the drawer
- Add new slot **drawer-content** to add additional content in the topbar

Sidebar-doc:
- Fix some css values


❤️ Thank you!
